### PR TITLE
Adds nginx location blocks for dashboard redirection

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -13,6 +13,16 @@ server {
 		return 301 https://smartaqnet.github.io;
 	}
 
+	#Dashboard redirection (with and without trailing slash)
+	location  ~ ^/dashboard/content/?$ {
+		if ($host ~ dev)
+		{
+			return 301 https://$host/en/dashboard;
+		}
+
+		return 301 https://smartaqnet.github.io/en/dashboard;
+	}
+
 	location /.well-known/acme-challenge/ {
 		root /var/www/certbot;
 	}
@@ -48,6 +58,16 @@ server {
 		{
 			return 301 https://smartaqnet.github.io;
 		}
+	}
+
+	#Dashboard redirection (with and without trailing slash)
+	location  ~ ^/dashboard/content/?$ {
+		if ($host ~ dev)
+		{
+			return 301 https://$host/en/dashboard;
+		}
+
+		return 301 https://smartaqnet.github.io/en/dashboard;
 	}
 
 	location /v1.0 {


### PR DESCRIPTION
Paul asked for a way to give workshop participants a canonical URL (http://api.smartaq.net/dashboard/content/) for the dashboard.
See: https://projects.teco.edu/issues/1862

I am not sure if this is the correct configuration file used for the api.smartaq.net server or if this is even wanted.